### PR TITLE
Adds dependence on mechanical_scanning_imaging_gazebo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mechanical_scanning_imaging_sonar_gazebo)
 
 find_package(catkin REQUIRED COMPONENTS roslint
   image_transport 
+  cv_bridge
   roscpp 
   sensor_msgs
   sonar_msgs)

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,8 @@
 
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>cmake_modules</test_depend>
+  <test_depend>tinyxml</test_depend>
 
   <build_depend>sonar_msgs</build_depend>
   


### PR DESCRIPTION
Resolve Brazilian-Institute-of-Robotics/mccr_simulator#70 
Overrides:
```
- mccr_dashboard:
  branch: monitoring_component_update

- mccr_simulator:
  branch: docker_test_correction

- mechanical_scanning_imaging_sonar_gazebo:
  branch: docker_test_correction
```